### PR TITLE
Add neon theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ See [CONTRIBUTING](./CONTRIBUTING.md).
 - [Frost](https://gitlab.com/ihciM/lightdm-frost)
 - [Arch theme](https://github.com/guillaumeboehm/lightdm-web-greeter-theme-arch)
 - [Aether](https://github.com/JezerM/Aether)
+- [Neon](https://github.com/hertg/lightdm-neon)
 
 [web-greeter-themes]: https://github.com/JezerM/web-greeter-themes "Web Greeter Themes"

--- a/src/assets/themes.json
+++ b/src/assets/themes.json
@@ -100,8 +100,7 @@
       "multiMonitor": false,
       "imagePrimary": "https://github.com/JezerM/Aether/raw/screenshots/screenshot.png",
       "imageSecondary": ""
-    }
-    ,
+    },
     {
       "name": "Neon",
       "author": "hertg",

--- a/src/assets/themes.json
+++ b/src/assets/themes.json
@@ -101,5 +101,15 @@
       "imagePrimary": "https://github.com/JezerM/Aether/raw/screenshots/screenshot.png",
       "imageSecondary": ""
     }
+    ,
+    {
+      "name": "Neon",
+      "author": "hertg",
+      "repo": "https://github.com/hertg/lightdm-neon",
+      "description": "A customizable theme for web-greeter in a nostalgic but modern neon look",
+      "multiMonitor": false,
+      "imagePrimary": "https://github.com/hertg/lightdm-neon/raw/fe9e334a1e5475c07bc39406a875a06a748cdbc8/docs/password.jpg",
+      "imageSecondary": ""
+    }
   ]
 }


### PR DESCRIPTION
I recently created and published [a theme](https://github.com/hertg/lightdm-neon) for your `web-greeter` and `nody-greeter`.
This PR adds my theme to the community themes section on the website.

Thanks a lot for active your work on those projects, I was very pleased to find out that someone is maintaining an alternative to the abandoned webkit2-greeter :)